### PR TITLE
Update field.storage.node.field_faces_of_ord.yml

### DIFF
--- a/config/sync/field.storage.node.field_faces_of_ord.yml
+++ b/config/sync/field.storage.node.field_faces_of_ord.yml
@@ -12,7 +12,7 @@ settings:
   target_type: node
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false


### PR DESCRIPTION
allow for more than one faces of ord entity reference in a weekly compass node.
hotfix done on prod - getting committed so it's not overwritten in the next release.