### PR TITLE
Add warning to README about composer and php version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Use a BASH command line (e.g. GIT BASH) for a Windows environment.
 5. `composer install` -- install all dependencies for the project. This can take some time.
     * For a Windows environment, this must be done in a BASH command line. Try GIT bash, included with the GIT installation, or Ubuntu Bash, new to Windows 10. 
 
+### Requirements: Composer and PHP Version
+
+Currently the project requires:
+* Composer 1 (you can use `composer self-update --1` to downgrade)
+* PHP 7.x
 
 ### [Acquia Dev Desktop (ADD)](https://dev.acquia.com/downloads)
 1. Open ADD


### PR DESCRIPTION
# Why composer version 1 is required

Currently there is errors about plugin version

```
Problem 1
    - composer/installers is locked to version v1.8.0 and an update of this package was not requested.
    - composer/installers v1.8.0 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 2
    - cweagans/composer-patches is locked to version 1.6.7 and an update of this package was not requested.
    - cweagans/composer-patches 1.6.7 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 3
    - drupal-composer/drupal-scaffold is locked to version 2.3.0 and an update of this package was not requested.
    - drupal-composer/drupal-scaffold 2.3.0 requires composer-plugin-api ^1.0.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 4
    - oomphinc/composer-installers-extender is locked to version v1.1.2 and an update of this package was not requested.
    - oomphinc/composer-installers-extender v1.1.2 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 5
    - simplesamlphp/composer-module-installer is locked to version v1.1.6 and an update of this package was not requested.
    - simplesamlphp/composer-module-installer v1.1.6 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 6
    - wikimedia/composer-merge-plugin is locked to version v1.4.1 and an update of this package was not requested.
    - wikimedia/composer-merge-plugin v1.4.1 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
  Problem 7
    - composer/installers v1.8.0 requires composer-plugin-api ^1.0 -> found composer-plugin-api[2.3.0] but it does not match the constraint.
    - jquery/inputmask 5.0.3 requires composer/installers ~1.0 -> satisfiable by composer/installers[v1.8.0].
    - jquery/inputmask is locked to version 5.0.3 and an update of this package was not requested.
```

This link: https://github.com/composer/composer/issues/8726

explains that composer 2 does not support plugins made for composer 1.

# Why php8 is not supported

Some dependencies don't seem to support it. I didn't save the error log from composer.