### PR TITLE
Policy hotfix 2 10 23

### DIFF
--- a/config/sync/core.entity_view_display.taxonomy_term.policy_definitions.default.yml
+++ b/config/sync/core.entity_view_display.taxonomy_term.policy_definitions.default.yml
@@ -18,14 +18,6 @@ content:
     label: hidden
     settings: {  }
     third_party_settings: {  }
-    weight: 1
-    region: content
-  field_policy_topic:
-    type: entity_reference_label
-    label: inline
-    settings:
-      link: false
-    third_party_settings: {  }
     weight: 0
     region: content
 hidden:
@@ -33,4 +25,5 @@ hidden:
   entity_print_view_pdf: true
   entity_print_view_word_docx: true
   feeds_item: true
+  field_policy_topic: true
   search_api_excerpt: true

--- a/config/sync/views.view.policy_definitions.yml
+++ b/config/sync/views.view.policy_definitions.yml
@@ -22,6 +22,7 @@ dependencies:
     - entity_reference_revisions
     - rest
     - serialization
+    - slick
     - taxonomy
     - text
     - user
@@ -730,9 +731,9 @@ display:
           empty_zero: false
           hide_alter_empty: true
           click_sort_column: value
-          type: text_default
+          type: slick_text
           settings: {  }
-          group_column: value
+          group_column: entity_id
           group_columns: {  }
           group_rows: true
           delta_limit: 0
@@ -925,11 +926,13 @@ display:
           1: AND
       defaults:
         title: false
+        group_by: false
         fields: false
         sorts: false
         filters: false
         filter_groups: false
         header: false
+      group_by: true
       display_description: ''
       header:
         area_text_custom:

--- a/config/sync/views.view.policy_definitions.yml
+++ b/config/sync/views.view.policy_definitions.yml
@@ -742,6 +742,22 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
+      sorts:
+        name:
+          id: name
+          table: taxonomy_term_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: taxonomy_term
+          entity_field: name
+          plugin_id: standard
+          order: ASC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
       filters:
         status:
           id: status
@@ -910,6 +926,7 @@ display:
       defaults:
         title: false
         fields: false
+        sorts: false
         filters: false
         filter_groups: false
         header: false


### PR DESCRIPTION
Post release realized I needed to:
-  hide the topic field in the default display for terms
- ensure terms in the QA view of definitions sort by term name alphabetically
- QA display needed aggregation and proper text formatting

Made changes on PROD and exported config