### PR TITLE
OR-902 

### DIFF
--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -6,4 +6,3 @@ ignored_config_entities:
   - 'webform_composite.*'
   - 'webform.*'
   - 'core.entity_view_display.node.webform.*'
-  - 'webform_custom_submissions*'

--- a/docroot/modules/custom/webform_custom_submissions/src/Form/TravelServicesForm.php
+++ b/docroot/modules/custom/webform_custom_submissions/src/Form/TravelServicesForm.php
@@ -31,25 +31,30 @@ class TravelServicesForm extends ConfigFormBase {
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->config('webform_custom_submissions.form');
+    $jira_settings = \Drupal::config('webform_custom_submissions.form');
     $form['BASE_URL'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Base Url for Jira'),
-      '#default_value' => $config->get('BASE_URL'),
+      '#default_value' => $jira_settings->get('BASE_URL'),
+      '#disabled' => TRUE,
     ];
     $form['REST_URL'] = [
       '#type' => 'textfield',
       '#title' => $this->t('Url of REST requests to Jira'),
-      '#default_value' => $config->get('REST_URL'),
+      '#default_value' => $jira_settings->get('REST_URL'),
+      '#disabled' => TRUE,
     ];
     $form['CREATE_ISSUE_URL'] = [
       '#type' => 'textfield',
       '#title' => $this->t('URL for issue creations requests to Jira'),
-      '#default_value' => $config->get('CREATE_ISSUE_URL'),
+      '#default_value' => $jira_settings->get('CREATE_ISSUE_URL'),
+      '#disabled' => TRUE,
     ];
     $form['USERNAME'] = [
       '#type' => 'textfield',
       '#title' => $this->t('User name authenticated with JIRA issue creation'),
-      '#default_value' => $config->get('USERNAME'),
+      '#default_value' => $jira_settings->get('USERNAME'),
+      '#disabled' => TRUE,
     ];
     $form['SERVER'] = [
       '#type' => 'textfield',
@@ -87,10 +92,6 @@ class TravelServicesForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     parent::submitForm($form, $form_state);
     $this->config('webform_custom_submissions.form')
-      ->set('BASE_URL', $form_state->getValue('BASE_URL'))
-      ->set('REST_URL', $form_state->getValue('REST_URL'))
-      ->set('CREATE_ISSUE_URL', $form_state->getValue('CREATE_ISSUE_URL'))
-      ->set('USERNAME', $form_state->getValue('USERNAME'))
       ->set('SERVER', $form_state->getValue('SERVER'))
       ->set('DOMESTIC_PROJECT', $form_state->getValue('DOMESTIC_PROJECT'))
       ->set('INTERNATIONAL_PROJECT', $form_state->getValue('INTERNATIONAL_PROJECT'))

--- a/docroot/modules/custom/webform_custom_submissions/src/JiraSubmissionHandler.php
+++ b/docroot/modules/custom/webform_custom_submissions/src/JiraSubmissionHandler.php
@@ -27,12 +27,13 @@ class JiraSubmissionHandler {
   public function __construct($config) {
     $this->jira_services_config = $config->get('webform_custom_submissions.form');
     $this->jira_custom_fields_config = $config->get('webform_custom_submissions.jira_custom_fields');
+    $jira_settings = \Drupal::config('webform_custom_submissions.form');
     $system_config = $config->get('system.passwords');
-    $this->username = $this->jira_services_config->get('USERNAME');
+    $this->username = $jira_settings->get('USERNAME');
     $this->password = $system_config->get('jira');
-    $issue_creation_url = $this->jira_services_config->get('CREATE_ISSUE_URL');
-    $this->create_issue_url = $this->jira_services_config->get('CREATE_ISSUE_URL');
-    $this->base_url = $this->jira_services_config->get('BASE_URL');
+    $issue_creation_url = $jira_settings->get('CREATE_ISSUE_URL');
+    $this->create_issue_url = $issue_creation_url;
+    $this->base_url = $jira_settings->get('BASE_URL');
     $this->domestic_project = $this->jira_services_config->get('DOMESTIC_PROJECT');
     $this->international_project = $this->jira_services_config->get('INTERNATIONAL_PROJECT');
     $this->submission_client = new Client(['base_uri' => $issue_creation_url]);


### PR DESCRIPTION
Remove webform_custom_submissions from config_ignore and have relevant configs stored in settings.php

Settings.php will need to have the following entries with values specific to each environment:

$config['webform_custom_submissions.form']['BASE_URL'] = 'BASE_URL value';
$config['webform_custom_submissions.form']['REST_URL'] = 'REST_URL value';
$config['webform_custom_submissions.form']['CREATE_ISSUE_URL'] = 'CREATE_ISSUE_URL value';
$config['webform_custom_submissions.form']['USERNAME'] = 'USERNAME value';